### PR TITLE
Clone trello#4 - Drag & Dropping Tasks

### DIFF
--- a/Practical-Builds/clone-trello/src/store.js
+++ b/Practical-Builds/clone-trello/src/store.js
@@ -36,6 +36,10 @@ export default new Vuex.Store({
     },
     UPDATE_TASK(state, { task, key, value }) {
       task[key] = value;
+    },
+    MOVE_TASK(state, { fromTasks, toTasks, taskIndex }) {
+      const taskToMove = fromTasks.splice(taskIndex, 1)[0]
+      toTasks.push(taskToMove)
     }
   }
 })

--- a/Practical-Builds/clone-trello/src/views/Board.vue
+++ b/Practical-Builds/clone-trello/src/views/Board.vue
@@ -16,6 +16,8 @@
             v-for="(task, $taskIndex) of column.tasks"
             :key="$taskIndex"
             @click="goToTask(task)"
+            draggable
+            @dragstart="pickupTask($event, $taskIndex, $columnIndex)"
           >
             <span class="w-full flex-no-shrink font-bold">
               {{ task.name }}
@@ -63,6 +65,12 @@ export default {
     createTask (e, tasks) {
       this.$store.commit('CREATE_TASK', { tasks, name: e.target.value })
       e.target.value = ''
+    },
+    pickupTask (e, taskIndex, fromColumnIndex) {
+      e.dataTransfer.effectAllowed = 'move'
+      e.dataTransfer.dropEffect = 'move'
+      e.dataTransfer.setData('task-index', taskIndex)
+      e.dataTransfer.setData('from-column-index', fromColumnIndex)
     },
     close () {
       this.$router.push({ name: 'board' })

--- a/Practical-Builds/clone-trello/src/views/Board.vue
+++ b/Practical-Builds/clone-trello/src/views/Board.vue
@@ -6,6 +6,9 @@
         class="column"
         v-for="(column, $columnIndex) of board.columns"
         :key="$columnIndex"
+        @drop="moveTask($event, column.tasks)"
+        @dragover.prevent
+        @dragenter.prevent
       >
         <div class="flex items-center mb-2 font-bold">
           {{ column.name }}
@@ -71,6 +74,17 @@ export default {
       e.dataTransfer.dropEffect = 'move'
       e.dataTransfer.setData('task-index', taskIndex)
       e.dataTransfer.setData('from-column-index', fromColumnIndex)
+    },
+    moveTask (e, toTasks) {
+      const fromColumnIndex = e.dataTransfer.getData('from-column-index')
+      const fromTasks = this.board.columns[fromColumnIndex].tasks
+      const taskIndex = e.dataTransfer.getData('task-index')
+
+      this.$store.commit('MOVE_TASK', {
+        fromTasks,
+        toTasks,
+        taskIndex
+      })
     },
     close () {
       this.$router.push({ name: 'board' })


### PR DESCRIPTION
To move around tasks from column to column using the browser's drag and drop API